### PR TITLE
remove cwd as it's not needed

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -197,7 +197,6 @@ export default {
     // With the custom format the puppet-int ouput looks like this:
     // error mongodb::service not in autoload module layout 3 7
     const helpers   = require("atom-linter");
-    const path      = require("path");
     const regexLine = /^(warning|error)\s(.*)\s(\d+)\s(\d+)$/;
     const regexFlag = /^skip.*/;
 
@@ -219,7 +218,6 @@ export default {
 
         const command = atom.config.get("linter-puppet-lint.executablePath");
         const file    = activeEditor.getPath();
-        const cwd     = path.dirname(file);
         const args    = ['--log-format','%{kind} %{message} %{line} %{column}']
 
         var optionsMap = require('./flags.js');
@@ -239,7 +237,7 @@ export default {
 
         args.push(file)
 
-        return helpers.exec(command, args, {stream: "stdout", cwd: cwd}).then(output => {
+        return helpers.exec(command, args, {stream: "stdout"}).then(output => {
           const toReturn = [];
           output.split(/\r?\n/).forEach(function (line) {
             const matches = regexLine.exec(line);


### PR DESCRIPTION
the `cwd` option to `atom-linter.exec` can cause trouble on a system with rbenv or rvm because the working directory may change the ruby that puppet-lint runs under

there doesn't seem to be any reference to the working directory in puppet-lint docs. The only reference in the source is [here](/rodjek/puppet-lint/blob/1.1.0/lib/puppet-lint/data.rb#L53), but that parameter is only used for relative paths and [TextEditor.getPath()](/AtomLinter/linter-puppet-lint/blob/v0.6.2/lib/main.js#L221) always returns a fully qualified path.