### PR TITLE
fix bug: oldVersion flag is incorrectly set

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -171,39 +171,27 @@ export default {
   },
 
   activate: () => {
-    var help_data = '';
+    const helpers = require("atom-linter");
+    const command = atom.config.get("linter-puppet-lint.executablePath");
+    const args    = ['--help'];
+
     require("atom-package-deps").install('linter-puppet-lint');
 
     // Check if puppet-lint has support for the %{column} placeholder
-    var command = atom.config.get("linter-puppet-lint.executablePath");
-    var version = require('child_process').spawn(command,['--help']);
-    version.stdout.on('data', function (data) {
-        help_data += data;
-    });
-    version.stdout.on('close', function (code) {
-      if (code) {
+    helpers.exec(command, args, {stream: "stdout"}).then(output => {
+      var regexColumn = /%{column}/;
+
+      if (regexColumn.exec(output) === null) {
+        atom.config.set("linter-puppet-lint.oldVersion", true);
         atom.notifications.addError(
-          "Your puppet-lint did not execute correctly!!!",
+          "You are using an old version of puppet-lint!!!",
           {
-            detail: "Please verify your puppet-lint executable path.\n"
+            detail: "Please upgrade you version of puppet-lint.\n"
             + "Check the README for further information."
           }
         );
       } else {
-        var regexColumn = /%{column}/;
-
-        if (regexColumn.exec(help_data) === null) {
-          atom.config.set("linter-puppet-lint.oldVersion", true);
-          atom.notifications.addError(
-            "You are using an old version of puppet-lint!!!",
-            {
-              detail: "Please upgrade you version of puppet-lint.\n"
-              + "Check the README for further information."
-            }
-          );
-        } else {
-          atom.config.set("linter-puppet-lint.oldVersion", false);
-        }
+        atom.config.set("linter-puppet-lint.oldVersion", false);
       }
     });
   },

--- a/lib/main.js
+++ b/lib/main.js
@@ -178,7 +178,7 @@ export default {
     require("atom-package-deps").install('linter-puppet-lint');
 
     // Check if puppet-lint has support for the %{column} placeholder
-    helpers.exec(command, args, {stream: "stdout"}).then(output => {
+    helpers.exec(command, args).then(output => {
       var regexColumn = /%{column}/;
 
       if (regexColumn.exec(output) === null) {

--- a/lib/main.js
+++ b/lib/main.js
@@ -171,14 +171,28 @@ export default {
   },
 
   activate: () => {
+    var help_data = '';
     require("atom-package-deps").install('linter-puppet-lint');
 
     // Check if puppet-lint has support for the %{column} placeholder
     var command = atom.config.get("linter-puppet-lint.executablePath");
     var version = require('child_process').spawn(command,['--help']);
     version.stdout.on('data', function (data) {
+        help_data += data;
+    });
+    version.stdout.on('close', function (code) {
+      if (code) {
+        atom.notifications.addError(
+          "Your puppet-lint did not execute correctly!!!",
+          {
+            detail: "Please verify your puppet-lint executable path.\n"
+            + "Check the README for further information."
+          }
+        );
+      } else {
         var regexColumn = /%{column}/;
-        if (regexColumn.exec(data) === null) {
+
+        if (regexColumn.exec(help_data) === null) {
           atom.config.set("linter-puppet-lint.oldVersion", true);
           atom.notifications.addError(
             "You are using an old version of puppet-lint!!!",
@@ -190,6 +204,7 @@ export default {
         } else {
           atom.config.set("linter-puppet-lint.oldVersion", false);
         }
+      }
     });
   },
 


### PR DESCRIPTION
The oldVersion was set incorrectly in case puppet-lint --help
output is too long (this is likely the case for those who
have installed many puppet-lint plugin). More details:
https://github.com/AtomLinter/linter-puppet-lint/issues/18