### PR TITLE
Remove macOS testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ matrix:
       rvm: 2.3.1
       env: ATOM_CHANNEL=beta
 
-    - os: osx
-      rvm: 2.2.2
-
 env:
   global:
     APM_TEST_PACKAGES: "language-puppet"


### PR DESCRIPTION
Travis-CI has become completely unusable for macOS testing, with builds consistently taking over 2 hours to finish queueing. As there have been virtually no bugs found specifically on this platform it isn't worth the developer headaches of waiting forever for builds on it.