### PR TITLE
Properly declare the member functions

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -11,7 +11,7 @@ let allSettings;
 
 export default {
   // Activate linter
-  activate: () => {
+  activate() {
     const helpers = require('atom-linter');
 
     subscriptions = new CompositeDisposable();
@@ -43,11 +43,11 @@ export default {
     });
   },
 
-  deactivate: () => {
+  deactivate() {
     subscriptions.dispose();
   },
 
-  provideLinter: () => {
+  provideLinter() {
     const helpers = require('atom-linter');
 
     return {


### PR DESCRIPTION
Function declaration using an arrow function in the global scope is invalid, and the cleaner transpilation in Atom v1.16.0 breaks on this method.

See https://github.com/atom/atom/pull/13823#issuecomment-286985411 for details.