### PR TITLE
Greenkeeper/eslint 4.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 ### Project specific config ###
+dist: trusty
 language: ruby
 
 matrix:
   include:
     - os: linux
-      rvm: 2.3.1
+      rvm: 2.3.4
 
     - os: linux
-      rvm: 2.3.1
+      rvm: 2.3.4
       env: ATOM_CHANNEL=beta
 
 env:

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "language-puppet"
   ],
   "devDependencies": {
-    "eslint": "^3.14.0",
+    "eslint": "^4.1.1",
     "eslint-config-airbnb-base": "^11.0.0",
     "eslint-plugin-import": "^2.0.1"
   },


### PR DESCRIPTION
I think the new glibc requirement comes because they rewrote the DOM in 1.19 in C++.