### PR TITLE
Respect project's puppet-lint.rc

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -68,10 +68,10 @@ export default {
           return [];
         }
 
-        // Setup const vars for later use
-        const path = require('path');
-        const file = activeEditor.getPath();
-        const cwd = path.dirname(file);
+        // To make use of a project's .puppet-lint.rc, execute linter from the root of this file's project
+        const filePath = activeEditor.getPath();
+        const [projectPath, projectRelativeFilePath] = atom.project.relativizePath(filePath);
+
         // With the custom format the puppet-int ouput looks like this:
         // error mongodb::service not in autoload module layout 3 7
         const regexLine = /^(warning|error)\s(.*)\s(\d+)\s(\d+)$/;
@@ -87,9 +87,9 @@ export default {
         });
 
         // Add the file to be checked to the arguments
-        args.push(file);
+        args.push(projectRelativeFilePath);
 
-        return helpers.exec(executablePath, args, { cwd, ignoreExitCode: true }).then((output) => {
+        return helpers.exec(executablePath, args, { cwd: projectPath, ignoreExitCode: true }).then((output) => {
           // If puppet-lint errors to stdout then redirect the message to stderr so it is caught
           if (/puppet-lint:/.exec(output)) {
             throw output;
@@ -107,7 +107,7 @@ export default {
                 severity: matches[1],
                 excerpt: matches[2],
                 location: {
-                  file,
+                  file: filePath,
                   position: helpers.generateRange(activeEditor, errLine, errCol),
                 },
               });

--- a/lib/main.js
+++ b/lib/main.js
@@ -68,7 +68,8 @@ export default {
           return [];
         }
 
-        // To make use of a project's .puppet-lint.rc, execute linter from the root of this file's project
+        // To respect this project's .puppet-lint.rc,
+        // execute puppet-lint from the root directory of this file's project
         const filePath = activeEditor.getPath();
         const [projectPath, projectRelativeFilePath] = atom.project.relativizePath(filePath);
 
@@ -89,32 +90,33 @@ export default {
         // Add the file to be checked to the arguments
         args.push(projectRelativeFilePath);
 
-        return helpers.exec(executablePath, args, { cwd: projectPath, ignoreExitCode: true }).then((output) => {
-          // If puppet-lint errors to stdout then redirect the message to stderr so it is caught
-          if (/puppet-lint:/.exec(output)) {
-            throw output;
-          }
-          const toReturn = [];
-
-          // Check for proper warnings and errors from stdout
-          output.split(/\r?\n/).forEach((line) => {
-            const matches = regexLine.exec(line);
-            if (matches != null) {
-              const errLine = Number.parseInt(matches[3], 10) - 1;
-              const errCol = Number.parseInt(matches[4], 10) - 1;
-
-              toReturn.push({
-                severity: matches[1],
-                excerpt: matches[2],
-                location: {
-                  file: filePath,
-                  position: helpers.generateRange(activeEditor, errLine, errCol),
-                },
-              });
+        return helpers.exec(executablePath, args, { cwd: projectPath, ignoreExitCode: true })
+          .then((output) => {
+            // If puppet-lint errors to stdout then redirect the message to stderr so it is caught
+            if (/puppet-lint:/.exec(output)) {
+              throw output;
             }
+            const toReturn = [];
+
+            // Check for proper warnings and errors from stdout
+            output.split(/\r?\n/).forEach((line) => {
+              const matches = regexLine.exec(line);
+              if (matches != null) {
+                const errLine = Number.parseInt(matches[3], 10) - 1;
+                const errCol = Number.parseInt(matches[4], 10) - 1;
+
+                toReturn.push({
+                  severity: matches[1],
+                  excerpt: matches[2],
+                  location: {
+                    file: filePath,
+                    position: helpers.generateRange(activeEditor, errLine, errCol),
+                  },
+                });
+              }
+            });
+            return toReturn;
           });
-          return toReturn;
-        });
       },
     };
   },


### PR DESCRIPTION
Fixes #22.  If you need anything else, let me know!

---

This is done by executing `puppet-lint` from the root directory of the linted
file's project.

For example, assume we have two directories open in Atom (say /project1 and
/project2) with the following files:

    /project1/.puppet-lint.rc

    /project2/.puppet-lint.rc
    /project2/modules/mymodule/manifests/do_something.pp

If we needed to lint `do_something.pp`, `puppet-lint` would be executed
with working directory `/project2` and look at path
`modules/mymodule/manifests/do_something.pp`.

Since `puppet-lint` is executed in `/project2`,
`/project2/.puppet-lint.rc` is obeyed.  `/project1`'s will only be used
for files inside `/project1`.