### PR TITLE
removing old version from config

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -28,7 +28,6 @@ export default {
       const regexColumn = /%{column}/;
 
       if (regexColumn.exec(output) === null) {
-        atom.config.set('linter-puppet-lint.oldVersion', true);
         atom.notifications.addError(
           'You are using an old version of puppet-lint!',
           {
@@ -36,8 +35,6 @@ export default {
               'Check the README for further information.',
           },
         );
-      } else {
-        atom.config.set('linter-puppet-lint.oldVersion', false);
       }
     });
   },
@@ -55,18 +52,6 @@ export default {
       scope: 'file',
       lintsOnChange: false,
       lint: (activeEditor) => {
-        // Check again if puppet-lint is too old to support column information
-        if (atom.config.get('linter-puppet-lint.oldVersion') === true) {
-          atom.notifications.addError(
-            'You are using an old version of puppet-lint!',
-            {
-              detail: 'Please upgrade your version of puppet-lint.\n' +
-                'Check the README for further information.',
-            },
-          );
-          return [];
-        }
-
         // To respect this project's .puppet-lint.rc,
         // execute puppet-lint from the root directory of this file's project
         const filePath = activeEditor.getPath();


### PR DESCRIPTION
Removing old version from config since it could be easily bypassed and
did not really perform dynamic checks post-activation.