### PR TITLE
remove defunct puppet-lint config setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,13 +197,8 @@
       "type": "boolean",
       "default": false
     },
-    "skip80Chars": {
-      "title": "Skip the 80chars check (puppet-lint <= 1.1.0)",
-      "type": "boolean",
-      "default": false
-    },
     "skip140Chars": {
-      "title": "Skip the 140chars check (puppet-lint >= 2.0.0)",
+      "title": "Skip the 140chars check",
       "type": "boolean",
       "default": false
     },


### PR DESCRIPTION
I forgot to remove the config option in #155.